### PR TITLE
fixed some word splitting issues

### DIFF
--- a/hadoop/IndexMapper.java
+++ b/hadoop/IndexMapper.java
@@ -16,8 +16,8 @@ public class IndexMapper extends Mapper<LongWritable, Text, Text, IntWritable>{
 
     public void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException{
         
-        String line = value.toString();
-        StringTokenizer tokenizer = new StringTokenizer(line);
+        String line = value.toString().toLowerCase();
+        StringTokenizer tokenizer = new StringTokenizer(line, " .,\"{}()-;");
         
         while (tokenizer.hasMoreTokens()){
             word.set(tokenizer.nextToken());


### PR DESCRIPTION
results after running on some code:

f*	(1 Mapper) 
(2 reducer) 
�*	(2 Indexer) 
+	(1 reducer) 
+=	(1 reducer) 
+val	(1 reducer) 
//	(2 reducer) (2 Mapper) (5 Indexer) 
//create	(1 Indexer) 
:	(1 reducer) 
=	(1 reducer) (1 Indexer) 
@override	(1 reducer) 
addinputpath	(1 Indexer) 
afsdir	(1 Indexer) 
an	(1 Mapper) 
and	(1 Indexer) 
apache	(6 Indexer) (3 reducer) (4 Mapper) 
based	(1 Mapper) (1 reducer) 
class	(1 reducer) (6 Indexer) (1 Mapper) 
context	(3 Mapper) (3 reducer) 
controller	(1 Indexer) 
copyfromafs	(2 Indexer) 
cs2510	(1 Indexer) 
destdir	(1 Indexer) 
exception	(5 Indexer) 
extends	(1 Mapper) (1 reducer) 
fileinputformat	(2 Indexer) 
fileoutputformat	(2 Indexer) 
for	(2 Indexer) (2 reducer) (1 Mapper) 
fs	(1 Indexer) 
generator	(1 Mapper) 
globalindex	(2 Indexer) 
globalindexmapper	(1 Mapper) 
globalindexreducer	(1 reducer) 
going	(1 Indexer) 
hadoop	(6 Indexer) (3 reducer) (4 Mapper) 
hdfs	(1 Indexer) 
hdfsdir	(2 Indexer) 
implemented	(4 Indexer) 
import	(8 Indexer) (6 Mapper) (5 reducer) 
index	(1 Mapper) 
index_1_file	(1 Indexer) 
indexer	(2 Indexer) 
indexfile	(1 Indexer) 
indexing	(1 reducer) 
indexmapper	(1 Indexer) 
indexreducer	(1 Indexer) 
input	(1 Indexer) 
inputpath	(3 Indexer) 
interruptedexception	(1 Mapper) (1 reducer) 
intwritable	(1 reducer) (2 Indexer) (1 Mapper) 
io	(4 Mapper) (3 reducer) (3 Indexer) 
ioexception	(2 Mapper) (1 reducer) 
iterable<text>	(1 reducer) 
java	(2 reducer) (2 Indexer) (2 Mapper) 
job	(14 Indexer) 
key	(2 reducer) (2 Mapper) 
lib	(2 Indexer) 
longwritable	(1 Mapper) 
made	(1 Indexer) 
map	(1 Mapper) 
map/reduce	(1 Indexer) 
mapper	(1 Indexer) (2 Mapper) 
mapper<text	(1 Mapper) 
mapreduce	(1 Mapper) (3 Indexer) (1 reducer) 
mv	(1 Indexer) 
mvhdfs	(1 Indexer) 
new	(3 Indexer) (1 reducer) 
not	(4 Indexer) 
on	(1 Indexer) (1 Mapper) (1 reducer) 
org	(3 reducer) (6 Indexer) (4 Mapper) 
out	(5 Indexer) 
output	(1 Indexer) 
outputpath	(3 Indexer) 
path	(3 Indexer) 
paths	(1 Indexer) 
println	(4 Indexer) 
project2	(1 Indexer) 
provided	(1 reducer) (1 Mapper) 
public	(2 Mapper) (6 Indexer) (2 reducer) 
reduce	(1 reducer) 
reducer	(2 reducer) (1 Indexer) 
reducer<text	(1 reducer) 
rmfromhdfs	(2 Indexer) 
sample	(1 Mapper) (1 reducer) 
set	(2 Indexer) 
setjarbyclass	(1 Indexer) 
setjobname	(1 Indexer) 
setmapperclass	(1 Indexer) 
setoutputkeyclass	(1 Indexer) 
setoutputpath	(1 Indexer) 
setoutputvalueclass	(1 Indexer) 
setreducerclass	(1 Indexer) 
sourcedir	(1 Indexer) 
static	(5 Indexer) 
string	(9 Indexer) (1 reducer) 
system	(4 Indexer) 
text	(2 Indexer) (6 reducer) (5 Mapper) 
text>	(1 Mapper) (1 reducer) 
the	(1 reducer) (4 Indexer) (1 Mapper) 
throws	(1 Mapper) (1 reducer) (5 Indexer) 
tostring	(1 reducer) 
total	(3 reducer) 
true	(1 Indexer) 
util	(1 Indexer) (1 Mapper) (1 reducer) 
val	(1 reducer) 
value	(2 Mapper) 
values	(2 reducer) 
various	(1 Indexer) 
void	(5 Indexer) (1 reducer) (1 Mapper) 
waitforcompletion	(1 Indexer) 
write	(1 Mapper) (1 reducer) 
yet	(4 Indexer)